### PR TITLE
Add Bootstrap typeahead support

### DIFF
--- a/src/jquery.ui.addresspicker.js
+++ b/src/jquery.ui.addresspicker.js
@@ -172,7 +172,7 @@
             'address': address + this.options.appendAddressString,
             'region': this.options.regionBias
         }, function(results, status) {
-            if (status == google.maps.GeocoderStatus.OK) {
+            if (status == google.maps.GeocoderStatus.OK && results) {
                 for (var i = 0; i < results.length; i++) {
                     results[i].label =  results[i].formatted_address;
                 };


### PR DESCRIPTION
I added an option to use Bootstraps [typeahead](http://twitter.github.io/bootstrap/javascript.html#typeahead) plugin instead of the autocomplete plugin.

There is a new option called `autocomplete`. If set to `'bootstrap'` it will use the boostrap plugin.

Please let me know if you want to support this.
