### PR TITLE
Don't try to update the address when the geocoder returns an empty result

### DIFF
--- a/src/jquery.ui.addresspicker.js
+++ b/src/jquery.ui.addresspicker.js
@@ -168,7 +168,7 @@
 
     _updateAddressPartsViaReverseGeocode: function(location){
       this.geocoder.geocode({'latlng': location.lat() + "," + location.lng()}, $.proxy(function(results, status){
-        if (status == google.maps.GeocoderStatus.OK)
+        if (status == google.maps.GeocoderStatus.OK){
 
           this._updateAddressParts(results[0]);
           this.element.val(results[0].formatted_address);
@@ -177,7 +177,8 @@
           if (this.options.updateCallback) {
             this.options.updateCallback(this.selectedResult, this._parseGeocodeResult(this.selectedResult));
           }
-        }, this));
+        }
+      }, this));
     },
 
     _parseGeocodeResult: function(geocodeResult){


### PR DESCRIPTION
The following error occurs when the geocoder returns an empty result (i.e. when dragging the marker into an ocean). This PR doesn't try to update the address parts in that case.

```
Uncaught TypeError: Cannot read property 'formatted_address' of undefined
```
