### PR TITLE
Added support for optional parameter bounds

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ Options (with default values)
   appendAddressString: "",
   draggableMarker: true,
   regionBias: null,
+  bounds: '',
   componentsFilter:'',
   updateCallback: null,
   reverseGeocode: false,

--- a/src/jquery.ui.addresspicker.js
+++ b/src/jquery.ui.addresspicker.js
@@ -17,6 +17,7 @@
         appendAddressString: "",
         draggableMarker: true,
         regionBias: null,
+        bounds: '',
         componentsFilter:'',
         updateCallback: null,
         reverseGeocode: false,
@@ -217,6 +218,7 @@
           'language': this.options.language,
           'address': address + this.options.appendAddressString,
           'region': this.options.regionBias,
+          'bounds': this.options.bounds,
           'components': this.options.componentsFilter
         }, function(results, status) {
             if (status == google.maps.GeocoderStatus.OK && results) {


### PR DESCRIPTION
I needed this param for my project and so I want to give these little changes back to the community ...

You can find more information about the optional parameter "bounds" in the offical documentation: https://developers.google.com/maps/documentation/geocoding/?hl=en
